### PR TITLE
Combine methods to get IpAddress

### DIFF
--- a/UtilServiceProvider.php
+++ b/UtilServiceProvider.php
@@ -44,7 +44,7 @@ class UtilServiceProvider implements ServiceProviderInterface
 
         if (class_exists(Whip::class)) {
             $c['whip'] = function () {
-                return new Whip(Whip::REMOTE_ADDR);
+                return new Whip(Whip::PROXY_HEADERS | Whip::REMOTE_ADDR);
             };
         }
 


### PR DESCRIPTION
Services may run under proxies, or handler request forward by other service. We need to use this method to have correct Ip Address.