### PR TITLE
EsSchema - Fix data type for MY_TEAM_MAPPING.account properties

### DIFF
--- a/es/Schema.php
+++ b/es/Schema.php
@@ -956,9 +956,9 @@ class Schema
             'parent_assessor_id' => ['type' => self::T_INT],
             'account'            => [
                 'properties' => [
-                    'id'         => ['type' => self::T_INT],
-                    'first_name' => ['type' => self::T_TEXT],
-                    'last_name'  => ['type' => self::T_TEXT],
+                    'id'         => ['type' => self::T_KEYWORD],
+                    'first_name' => ['type' => self::T_KEYWORD],
+                    'last_name'  => ['type' => self::T_KEYWORD],
                     'avatar'     => ['type' => self::T_TEXT],
                 ],
             ],


### PR DESCRIPTION
Ref commit https://github.com/go1com/util/commit/eca5b36839bb7d407cebe2c5d2cc9d0d1cd166a4.
Due error at https://code.go1.com.au/microservices/index/-/jobs/149716
`1) go1\index\tests\consumer\services\ConsumerMiddlewareTest::testSkipLegacy
Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"mapper [account.last_name] of different type, current_type [keyword], merged_type [text]"}],"type":"illegal_argument_exception","reason":"mapper [account.last_name] of different type, current_type [keyword], merged_type [text]"},"status":400}`