### PR TITLE
Set random flag on UserClient

### DIFF
--- a/clients/UserClient.php
+++ b/clients/UserClient.php
@@ -82,6 +82,7 @@ class UserClient
                 'portal'     => $instance,
                 'email'      => $mail,
                 'password'   => $pass ?: Uuid::uuid4()->toString(),
+                'random'     => !$pass,
                 'first_name' => $first,
                 'last_name'  => $last,
                 'data'       => $data,


### PR DESCRIPTION
Users created through the public api do not get a one time login link in the email, and a password can't be set for the user either. It seems the notify service consumer expects to see the "rand" flag for that.
So there it is.