### PR TITLE
GO1P-22052: Added a collection type "content_loader"

### DIFF
--- a/collection/CollectionTypes.php
+++ b/collection/CollectionTypes.php
@@ -5,4 +5,5 @@ namespace go1\util\collection;
 class CollectionTypes
 {
     const DEFAULT = 'default';
+    const CONTENT_LOADER = 'content_loader';
 }


### PR DESCRIPTION
To extend the explore service with functionality to handle content loader business requirements, we need to add a collection type named "content_loader"