### PR TITLE
Es Event Parent is no more

### DIFF
--- a/es/mock/EsEventMockTrait.php
+++ b/es/mock/EsEventMockTrait.php
@@ -50,7 +50,6 @@ trait EsEventMockTrait
             'type'    => Schema::O_EVENT,
             'id'      => $options['id'] ?? ($autoId + 1),
             'body'    => $event,
-            'parent'  => $options['parent']['id'] ?? $options['lo_id'],
             'refresh' => true,
         ]);
     }


### PR DESCRIPTION
The commit https://github.com/go1com/util_core/commit/661f5227bc9ad54b5214dabfd8379ef472d41746 removed the parent from ES. This fixes an error in explore service when running tests.