### PR TITLE
PRO-2232: add Spanish & Portuguese support to `notify` for Mexico & Brazil locales

### DIFF
--- a/Languages.php
+++ b/Languages.php
@@ -297,7 +297,9 @@ class Languages
         'au'    => 'en-AU',
         'en-au' => 'en-AU',
         'en-us' => 'en',
+        'mx'    => 'es',
         'pt-pt' => 'pt-PT',
+        'br'    => 'pt-BR',
         'vi'    => 'vi',
         'no'    => 'nn',
     ];
@@ -306,8 +308,10 @@ class Languages
         'AU' => 'en-au',
         'US' => 'en-us',
         'PT' => 'pt-pt',
+        'BR' => 'pt-br',
         'DE' => 'de',
         'ES' => 'es',
+        'MX' => 'es',
         'VN' => 'vi',
         'NO' => 'no',
     ];

--- a/tests/LanguagesTest.php
+++ b/tests/LanguagesTest.php
@@ -10,7 +10,9 @@ class LanguagesTest extends TestCase
 {
     public function testLanguageCode()
     {
-        $this->assertEquals('nn', Languages::getLanguageCode('no'));
         $this->assertEquals('en', Languages::getLanguageCode('go1'));
+        $this->assertEquals('nn', Languages::getLanguageCode('no'));
+        $this->assertEquals('es', Languages::getLanguageCode('mx'));
+        $this->assertEquals('pt-Br', Languages::getLanguageCode('br'));
     }
 }


### PR DESCRIPTION
PRO-2232: add Spanish & Portuguese support to `notify` for Mexico & Brazil locales