### PR TITLE
PRO-3243 add the event_type property

### DIFF
--- a/clients/RealtimeClient.php
+++ b/clients/RealtimeClient.php
@@ -31,6 +31,7 @@ class RealtimeClient
                     'tag'         => $data['tag'] ?? null,
                     'from'        => $data['from'] ?? null,
                     'instance_id' => $data['instance_id'] ?? null,
+                    'envent_type' => $data['event_type'] ?? null,
                 ],
             ]);
         } catch (RequestException $e) {

--- a/clients/RealtimeClient.php
+++ b/clients/RealtimeClient.php
@@ -31,7 +31,7 @@ class RealtimeClient
                     'tag'         => $data['tag'] ?? null,
                     'from'        => $data['from'] ?? null,
                     'instance_id' => $data['instance_id'] ?? null,
-                    'envent_type' => $data['event_type'] ?? null,
+                    'event_type' => $data['event_type'] ?? null,
                 ],
             ]);
         } catch (RequestException $e) {

--- a/clients/RealtimeClient.php
+++ b/clients/RealtimeClient.php
@@ -31,7 +31,8 @@ class RealtimeClient
                     'tag'         => $data['tag'] ?? null,
                     'from'        => $data['from'] ?? null,
                     'instance_id' => $data['instance_id'] ?? null,
-                    'event_type' => $data['event_type'] ?? null,
+                    'event_type'  => $data['event_type'] ?? null,
+                    'transient'   => $data['transient'] ?? null,
                 ],
             ]);
         } catch (RequestException $e) {

--- a/tests/clients/RealtimeClientTest.php
+++ b/tests/clients/RealtimeClientTest.php
@@ -37,6 +37,8 @@ class RealtimeClientTest extends UtilTestCase
                                 'tag'         => 'tag',
                                 'from'        => 'from',
                                 'instance_id' => 1,
+                                'transient'   => true,
+                                'event_type'  => 'unit-test',
                             ],
                         ]
                         , $options);
@@ -67,6 +69,8 @@ class RealtimeClientTest extends UtilTestCase
             'tag'         => 'tag',
             'from'        => 'from',
             'instance_id' => 1,
+            'transient'   => true,
+            'event_type'  => 'unit-test',
         ];
         $client->notify(1, $data);
     }


### PR DESCRIPTION
We've recently added an event_type to the realtime /notification POST body such that realtime didn't need to improve the event sending functionality of realtime. This MR adds the property to the call in the Realtime client.